### PR TITLE
have 'tags center' return NA values from C++ code instead of DOUBLE_MAX

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "rapidxml.h"
+#include <Rcpp.h> // Only for 'NA_REAL'
 
 // APS not good pratice to have all the headers included here, adds to compile time
 // better to #include as and where needed, ideally in source rather than headers,
@@ -102,7 +103,7 @@ struct RawNode
     osmid_t id;
     std::string _version = "", _timestamp = "", _changeset = "", _uid = "", _user = ""; // metadata
     std::vector <std::string> key, value;
-    double lat = DOUBLE_MAX, lon = DOUBLE_MAX;
+    double lat = NA_REAL, lon = NA_REAL;
 };
 
 struct Node
@@ -110,7 +111,7 @@ struct Node
     osmid_t id;
     std::string _version = "", _timestamp = "", _changeset = "", _uid = "", _user = ""; // metadata
     std::map <std::string, std::string> key_val;
-    double lat = DOUBLE_MAX, lon = DOUBLE_MAX;
+    double lat = NA_REAL, lon = NA_REAL;
 };
 
 /* Traversing the XML tree means keys and values are read sequentially and
@@ -121,7 +122,7 @@ struct RawWay
 {
     osmid_t id;
     std::string _version, _timestamp, _changeset, _uid, _user; // metadata
-    double _lat = DOUBLE_MAX, _lon = DOUBLE_MAX; // center
+    double _lat = NA_REAL, _lon = NA_REAL; // center
     std::vector <std::string> key, value;
     std::vector <osmid_t> nodes;
 };
@@ -130,7 +131,7 @@ struct OneWay
 {
     osmid_t id;
     std::string _version, _timestamp, _changeset, _uid, _user; // metadata
-    double _lat = DOUBLE_MAX, _lon = DOUBLE_MAX; // center
+    double _lat = NA_REAL, _lon = NA_REAL; // center
     std::map <std::string, std::string> key_val;
     std::vector <osmid_t> nodes;
 };
@@ -141,7 +142,7 @@ struct RawRelation
     osmid_t id;
     std::string member_type;
     std::string _version, _timestamp, _changeset, _uid, _user; // metadata
-    double _lat = DOUBLE_MAX, _lon = DOUBLE_MAX; // center
+    double _lat = NA_REAL, _lon = NA_REAL; // center
     // APS would (key,value) be better in a std::map?
     std::vector <std::string> key, value, role_node, role_way, role_relation;
     std::vector <osmid_t> nodes;
@@ -155,7 +156,7 @@ struct Relation
     osmid_t id;
     std::string rel_type;
     std::string _version, _timestamp, _changeset, _uid, _user; // metadata
-    double _lat = DOUBLE_MAX, _lon = DOUBLE_MAX; // center
+    double _lat = NA_REAL, _lon = NA_REAL; // center
     std::map <std::string, std::string> key_val;
     // Relations may have nodes as members, but these are not used here.
     std::vector <std::pair <osmid_t, std::string> > nodes; // str = role


### PR DESCRIPTION
The only thing in your current PR https://github.com/ropensci/osmdata/pull/316 that made me uneasy was that the "center" columns were returned from the C++ code with junk data (platform-dependent values of `DOUBLE_MAX`), and then only discarded as a last step in the main `get_osmdata_df()` function. I'd prefer to filter these out as early as possible in the workflow. This PR to your current branch changes the current junk `DOUBLE_MAX` values to `NA`.  That will at least enable your current `get_center_from_cpp_output()` function to be modified so that instead of
``` r
  has_data <- apply (this, 2, function (i) any (nzchar (i)))
```
you could have `any(!is.na(i))`. That function would then return empty objects when `tags` are requested without `centre`. There might be even earlier points in the C++ code where that could be filtered out, but that change would at least make me more comfortable here. thanks :+1: 